### PR TITLE
Add mission board UI elements for unlock controls

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Normalize text files and make sure Lua/Markdown are treated as text so GitHub shows diffs
+* text=auto
+*.lua text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+
+# Explicitly mark common binary formats as binary so they aren't misdetected as text
+*.zip binary
+*.pak binary
+*.exe binary
+*.dll binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore generated binary artifacts; build locally when needed
+dist/
+*.zip

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Mission Board Unlock (Darktide Mod)
+
+A Darktide client-side mod that removes the mission board refresh cooldown, adds a manual **Refresh Board** button, and exposes selector buttons for choosing a map and difficulty. Designed for modded realms where UI and client-side gating can be bypassed using the official Mod Framework.
+
+## Features
+- **No cooldown:** Disables the 60-minute refresh lock on the mission board timer UI and client gate.
+- **Manual refresh:** Adds a "Refresh Board" button to immediately request new missions. The board also auto-refreshes when you open it.
+- **Map & difficulty selectors:** Buttons let you cycle choices and request rerolls until the board matches your picks.
+
+## Installation
+Install directly from source (no binary downloads are included):
+1. Ensure you are running the Darktide Mod Framework in a modded realm.
+2. Copy the `scripts/mods/mission_board_unlock` folder into your mod directory (e.g., `<Darktide>/mods` depending on your loader).
+3. Enable the mod in the Mod Framework launcher or via your mod loader config.
+
+## Usage
+- Open the mission board. The timer will stay unlocked and the **Refresh Board** button will be available immediately.
+- Use the map and difficulty selector buttons on the board to cycle through options.
+- Click **Refresh Board** to re-request missions (it also auto-refreshes on open). If the backend does not allow parameterized requests, the mod will reroll once until the selections appear.
+
+## Notes
+- This mod focuses on client-side UI gating. If the backend enforces rotation intervals, you may see repeated missions until the server rotates or accepts another refresh request.
+- Keep this mod within modded realms to avoid conflicts with anti-cheat or matchmaking expectations.
+- The repository intentionally ships **no** binary artifacts (no zip or dist outputs). Keep uploads text-only so GitHub never sees unsupported binaries.
+- A small status label ("Mission Board Unlock") appears under the selectors when the mod is active inside the mission board UI.
+
+## Development
+- Main entrypoint: `scripts/mods/mission_board_unlock/mission_board_unlock.lua`
+- Metadata: `scripts/mods/mission_board_unlock/mod_data.lua`
+- Localization strings live in `scripts/mods/mission_board_unlock/localization/localization.lua`
+  
+## Binary-free policy
+- The repo contains only text-based source files (Lua + Markdown). No `.zip`, `.pak`, or other compiled assets are committed.
+- `.gitattributes` and `.gitignore` ensure binary formats stay out of version control so the project remains compatible with GitHub.

--- a/scripts/mods/mission_board_unlock/localization/localization.lua
+++ b/scripts/mods/mission_board_unlock/localization/localization.lua
@@ -1,0 +1,32 @@
+return {
+mod_name = {
+en = "Mission Board Unlock",
+},
+mod_description = {
+en = "Removes the mission board cooldown, adds a manual refresh button, and exposes map/difficulty dropdowns.",
+},
+unlock_board = {
+en = "Disable mission board cooldown",
+},
+allow_manual_refresh = {
+en = "Enable manual refresh button",
+},
+respect_backend_lock = {
+en = "Keep backend cooldown (if any)",
+},
+refresh_button = {
+en = "Refresh Board",
+},
+map_dropdown_label = {
+en = "Preferred Map",
+},
+difficulty_dropdown_label = {
+    en = "Preferred Difficulty",
+},
+status_label_loading = {
+    en = "Mission Board Unlock: loading...",
+},
+status_label_unlocked = {
+    en = "Mission Board Unlock: cooldown disabled",
+}
+}

--- a/scripts/mods/mission_board_unlock/mission_board_unlock.lua
+++ b/scripts/mods/mission_board_unlock/mission_board_unlock.lua
@@ -1,0 +1,273 @@
+local mod = get_mod("mission_board_unlock")
+
+-- Utility: reads user config flags
+local function is_enabled(setting_id)
+    return mod:get(setting_id) ~= false
+end
+
+-- Attempt to pull map/difficulty catalogs at load so selectors can be populated
+local map_options = {
+    { text = mod:localize("map_dropdown_label"), value = "any" },
+}
+local difficulty_options = {
+    { text = mod:localize("difficulty_dropdown_label"), value = "any" },
+}
+
+-- Keep state to avoid infinite rerolls
+local rerolled_for_preferences = false
+
+-- Populate selectors when the mission board UI module is loaded
+mod:hook_require("scripts/ui/views/mission_board_view/mission_board_view_definitions", function(definitions)
+    if not definitions then
+        return definitions
+    end
+
+    -- Different Darktide versions expose either `widgets` or `widget_definitions`
+    local widgets = definitions.widgets or definitions.widget_definitions
+
+    if widgets then
+        -- Helper to prepend new widget definitions safely
+        local function insert_widget(name, widget)
+            if not widgets[name] then
+                widgets[name] = widget
+            end
+        end
+
+        insert_widget("refresh_button", {
+            pass_template = "button_primary",
+            scenegraph_id = "panel_area",
+            content = {
+                text = mod:localize("refresh_button"),
+                hotspot = {},
+            },
+            style = {
+                size = { 320, 42 },
+                offset = { 0, -90, 0 },
+            },
+        })
+
+        insert_widget("map_button", {
+            pass_template = "button_secondary",
+            scenegraph_id = "panel_area",
+            content = {
+                label = mod:localize("map_dropdown_label"),
+                text = mod:localize("map_dropdown_label"),
+                hotspot = {},
+            },
+            style = {
+                size = { 320, 36 },
+                offset = { 0, -36, 0 },
+            },
+        })
+
+        insert_widget("difficulty_button", {
+            pass_template = "button_secondary",
+            scenegraph_id = "panel_area",
+            content = {
+                label = mod:localize("difficulty_dropdown_label"),
+                text = mod:localize("difficulty_dropdown_label"),
+                hotspot = {},
+            },
+            style = {
+                size = { 320, 36 },
+                offset = { 0, 12, 0 },
+            },
+        })
+
+        insert_widget("unlock_status", {
+            pass_template = "text_area",
+            scenegraph_id = "panel_area",
+            content = {
+                text = mod:localize("status_label_loading"),
+            },
+            style = {
+                text_color = { 255, 200, 255, 200 },
+                font_size = 18,
+                size = { 320, 60 },
+                offset = { 0, 60, 0 },
+            },
+        })
+    end
+
+    return definitions
+end)
+
+local function unlock_refresh_state(self)
+    if not is_enabled("unlock_board") then
+        return
+    end
+
+    self._cooldown_time = 0
+    self._refresh_cooldown = 0
+    self._refresh_locked = false
+
+    local service = self._mission_board and self._mission_board._mission_board_service
+    if service then
+        service._refresh_cooldown = 0
+        service._refresh_locked = false
+        service._next_refresh_time = 0
+    end
+
+    if self._widgets_by_name then
+        local button = self._widgets_by_name.refresh_button
+        if button and button.content then
+            button.content.disabled = false
+        end
+
+        local status = self._widgets_by_name.unlock_status
+        if status and status.content then
+            status.content.text = mod:localize("status_label_unlocked")
+        end
+    end
+end
+
+local function refresh_board(self, preferred_map, preferred_difficulty)
+    local service = self._mission_board and self._mission_board._mission_board_service
+    if service and service.refresh_missions then
+        service:refresh_missions({
+            preferred_map = preferred_map,
+            preferred_difficulty = preferred_difficulty,
+        })
+        mod:echo("Mission board refreshed (cooldown bypassed).")
+    else
+        mod:echo("Mission board service unavailable; cannot refresh.")
+    end
+end
+
+local function cycle_option(widget, options)
+    if not widget or not widget.content or not options then
+        return nil
+    end
+
+    local current_index = widget.content._current_index or 1
+    local next_index = current_index + 1
+    if next_index > #options then
+        next_index = 1
+    end
+
+    widget.content._current_index = next_index
+    widget.content.text = string.format("%s: %s", widget.content.label, options[next_index].text)
+
+    return options[next_index].value
+end
+
+local function ensure_selector_text(widget, options)
+    if widget and widget.content and options and not widget.content._current_index then
+        widget.content._current_index = 1
+        widget.content.text = string.format("%s: %s", widget.content.label, options[1].text)
+    end
+end
+
+local function read_selector_value(widget, options)
+    if widget and widget.content and widget.content._current_index then
+        return options[widget.content._current_index].value
+    end
+
+    return "any"
+end
+
+-- Hook the mission board view/controller to disable timers and add callbacks
+mod:hook_require("scripts/ui/views/mission_board_view/mission_board_view", function(view)
+    -- force cooldown off as soon as the view opens
+    mod:hook_safe(view, "on_enter", function(self)
+        unlock_refresh_state(self)
+
+        ensure_selector_text(self._widgets_by_name and self._widgets_by_name.map_button, map_options)
+        ensure_selector_text(self._widgets_by_name and self._widgets_by_name.difficulty_button, difficulty_options)
+
+        if is_enabled("allow_manual_refresh") then
+            refresh_board(self)
+        end
+    end)
+
+    -- keep cooldown disabled while the view runs
+    mod:hook_safe(view, "update", function(self, ...)
+        unlock_refresh_state(self)
+
+        local map_widget = self._widgets_by_name and self._widgets_by_name.map_button
+        local diff_widget = self._widgets_by_name and self._widgets_by_name.difficulty_button
+        ensure_selector_text(map_widget, map_options)
+        ensure_selector_text(diff_widget, difficulty_options)
+
+        if map_widget and map_widget.content and map_widget.content.hotspot and map_widget.content.hotspot.on_pressed then
+            cycle_option(map_widget, map_options)
+        end
+
+        if diff_widget and diff_widget.content and diff_widget.content.hotspot and diff_widget.content.hotspot.on_pressed then
+            cycle_option(diff_widget, difficulty_options)
+        end
+
+        local button = self._widgets_by_name and self._widgets_by_name.refresh_button
+        if button and button.content and button.content.hotspot and button.content.hotspot.on_pressed then
+            local preferred_map = read_selector_value(map_widget, map_options)
+            local preferred_difficulty = read_selector_value(diff_widget, difficulty_options)
+
+            refresh_board(self, preferred_map, preferred_difficulty)
+            self._refresh_locked = not is_enabled("unlock_board")
+        end
+    end)
+
+    -- override mission selection/refresh pipeline to respect dropdown choices when possible
+    mod:hook_safe(view, "_handle_backend_mission_result", function(self, missions)
+        local preferred_map = read_selector_value(self._widgets_by_name and self._widgets_by_name.map_button, map_options)
+        local preferred_difficulty = read_selector_value(self._widgets_by_name and self._widgets_by_name.difficulty_button, difficulty_options)
+
+        local function matches_preferences(mission)
+            local ok_map = preferred_map == "any" or mission.map == preferred_map or mission.map_name == preferred_map
+            local ok_diff = preferred_difficulty == "any" or mission.difficulty == preferred_difficulty or mission.challenge == preferred_difficulty
+            return ok_map and ok_diff
+        end
+
+        if preferred_map ~= "any" or preferred_difficulty ~= "any" then
+            local all_match = true
+            for _, mission in pairs(missions or {}) do
+                if not matches_preferences(mission) then
+                    all_match = false
+                    break
+                end
+            end
+
+            -- If nothing matches, and backend refresh is allowed, reroll once
+            if not all_match and not is_enabled("respect_backend_lock") and not rerolled_for_preferences then
+                rerolled_for_preferences = true
+                refresh_board(self, preferred_map, preferred_difficulty)
+                return
+            end
+        end
+
+        rerolled_for_preferences = false
+    end)
+
+    return view
+end)
+
+-- Fallback catalog population: try to read missions when the service is loaded
+mod:hook_require("scripts/managers/live_event/live_event_manager", function(manager)
+    mod:hook_safe(manager, "_cache_missions", function(self, missions)
+        if not missions then
+            return
+        end
+
+        local seen_maps = {}
+        local seen_difficulties = {}
+        for _, mission in pairs(missions) do
+            if mission.map and not seen_maps[mission.map] then
+                seen_maps[mission.map] = true
+                table.insert(map_options, { text = mission.map, value = mission.map })
+            end
+            if mission.difficulty and not seen_difficulties[mission.difficulty] then
+                seen_difficulties[mission.difficulty] = true
+                table.insert(difficulty_options, { text = mission.difficulty, value = mission.difficulty })
+            end
+        end
+    end)
+
+    return manager
+end)
+
+-- Simple debug log so users can confirm the mod loaded
+mod:echo(
+    "Mission Board Unlock loaded. Cooldowns disabled: %s, manual refresh: %s",
+    tostring(is_enabled("unlock_board")),
+    tostring(is_enabled("allow_manual_refresh"))
+)

--- a/scripts/mods/mission_board_unlock/mod_data.lua
+++ b/scripts/mods/mission_board_unlock/mod_data.lua
@@ -1,0 +1,28 @@
+local mod = get_mod("mission_board_unlock")
+
+return {
+name = mod:localize("mod_name"),
+description = mod:localize("mod_description"),
+author = "Community",
+version = "1.0.0",
+hot_reload = true,
+options = {
+widgets = {
+{
+setting_id = "unlock_board",
+type = "checkbox",
+default_value = true,
+},
+{
+setting_id = "allow_manual_refresh",
+type = "checkbox",
+default_value = true,
+},
+{
+setting_id = "respect_backend_lock",
+type = "checkbox",
+default_value = false,
+},
+}
+}
+}


### PR DESCRIPTION
## Summary
- add visible refresh, map, and difficulty selector widgets to the mission board view with cycling input handling
- keep cooldown removal active while the view runs and display an on-board status label for the unlock state
- update localization and README usage notes to reflect the selector buttons and in-game status label

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69191125a038833180f195482b1023ba)