### PR TITLE
Add DMF .mod manifest for mission board unlock

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Normalize text files and make sure Lua/Markdown are treated as text so GitHub shows diffs
+* text=auto
+*.lua text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+
+# Explicitly mark common binary formats as binary so they aren't misdetected as text
+*.zip binary
+*.pak binary
+*.exe binary
+*.dll binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore generated binary artifacts; build locally when needed
+dist/
+*.zip

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Removes the mission board cooldown, adds a manual **Refresh Board** button, and 
 3. Ensure `mod_load_order.txt` contains **only** the folder names (one per line) that match your installed mod folders:
    - `dmf` (the Darktide Mod Framework folder name)
    - `mission_board_unlock`
-4. Confirm `mission_board_unlock.mod` exists in the installed folder; this manifest is what DMF loads. `mod.json` mirrors the same metadata and both point `script_path` to `scripts/mods/mission_board_unlock/mod` (which loads `mod.lua`, then `mission_board_unlock.lua`).
+4. Confirm `mission_board_unlock.mod` exists in the installed folder; this manifest is what DMF loads. `mod.json` mirrors the same metadata, declares `dmf` as a dependency, and both point `script_path` to `scripts/mods/mission_board_unlock/mod` (which loads `mod.lua`, then `mission_board_unlock.lua`).
 5. Start the game in a modded realm. You should see `Mission Board Unlock entrypoint loaded (mission_board_unlock.lua)` in the console when the loader picks up the mod.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Removes the mission board cooldown, adds a manual **Refresh Board** button, and 
 3. Ensure `mod_load_order.txt` contains **only** the folder names (one per line) that match your installed mod folders:
    - `dmf` (the Darktide Mod Framework folder name)
    - `mission_board_unlock`
-4. Confirm `mission_board_unlock.mod` exists in the installed folder; this manifest is what DMF loads. `mod.json` mirrors the same metadata and both point `script_path` to `scripts/mods/mission_board_unlock/mission_board_unlock.lua`.
+4. Confirm `mission_board_unlock.mod` exists in the installed folder; this manifest is what DMF loads. `mod.json` mirrors the same metadata and both point `script_path` to `scripts/mods/mission_board_unlock/mod` (which loads `mod.lua`, then `mission_board_unlock.lua`).
 5. Start the game in a modded realm. You should see `Mission Board Unlock entrypoint loaded (mission_board_unlock.lua)` in the console when the loader picks up the mod.
 
 ## Usage
@@ -23,7 +23,7 @@ Removes the mission board cooldown, adds a manual **Refresh Board** button, and 
 ## Files
 - `mission_board_unlock.mod`: DMF manifest the loader consumes to locate scripts and options.
 - `mod.json`: Manifest metadata (including `script_path`).
-- `mod.lua`: Optional helper kept for compatibility; the manifest now points directly to `mission_board_unlock.lua`.
+- `mod.lua`: Helper entrypoint that loads localization and then `mission_board_unlock.lua`.
 - `mod_data.lua`: Mod options and descriptions.
 - `mission_board_unlock.lua`: Core logic for disabling the cooldown, injecting UI controls, and handling refreshes (and logs the entrypoint load message).
 - `localization/localization.lua`: Localization strings for UI labels and settings.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Removes the mission board cooldown, adds a manual **Refresh Board** button, and 
 3. Ensure `mod_load_order.txt` contains **only** the folder names (one per line) that match your installed mod folders:
    - `dmf` (the Darktide Mod Framework folder name)
    - `mission_board_unlock`
-4. Confirm `mission_board_unlock.mod` exists in the installed folder; this manifest is what DMF loads. `mod.json` mirrors the same metadata, declares `dmf` as a dependency, and both point `script_path` to `scripts/mods/mission_board_unlock/mod` (which loads `mod.lua`, then `mission_board_unlock.lua`).
+4. Confirm `mission_board_unlock.mod` exists in the installed folder; this manifest is what DMF loads. `mod.json` mirrors the same metadata, declares `dmf` as a dependency, and both point `script_path` to `scripts/mods/mission_board_unlock/mod.lua` (which loads `mod.lua`, then `mission_board_unlock.lua`).
 5. Start the game in a modded realm. You should see `Mission Board Unlock entrypoint loaded (mission_board_unlock.lua)` in the console when the loader picks up the mod.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Mission Board Unlock (Darktide Mod)
+
+Removes the mission board cooldown, adds a manual **Refresh Board** button, and exposes map/difficulty selectors so you can reroll missions at will in modded realms.
+
+## Installation
+1. Create the folder structure exactly as shown (all files are required by the loader):
+   - `mission_board_unlock/`
+   - `mission_board_unlock/localization/`
+   - Place `mission_board_unlock.mod`, `mod.json`, `mod.lua`, `mod_data.lua`, and `mission_board_unlock.lua` directly inside `mission_board_unlock/`.
+   - Place `localization.lua` inside `mission_board_unlock/localization/`.
+2. Copy the entire `mission_board_unlock/` folder to `<Darktide>/mods/` so the path is `<Darktide>/mods/mission_board_unlock/`.
+3. Ensure `mod_load_order.txt` contains **only** the folder names (one per line) that match your installed mod folders:
+   - `darktide-mod-framework` (from DMF)
+   - `mission_board_unlock`
+4. Confirm `mission_board_unlock.mod` exists in the installed folder; this manifest is what DMF loads. `mod.json` is kept for metadata and uses `script_path = "mod"` to point at `mod.lua`.
+5. Start the game in a modded realm. You should see `Mission Board Unlock entrypoint loaded (mod.lua)` in the console when the loader picks up the mod.
+
+## Usage
+- Open the mission board; the cooldown will be disabled automatically.
+- Use the **Refresh Board**, **Preferred Map**, and **Preferred Difficulty** buttons that appear on the board panel to cycle options and reroll missions.
+- The status label updates when the board is unlocked.
+
+## Files
+- `mission_board_unlock.mod`: DMF manifest the loader consumes to locate scripts and options.
+- `mod.json`: Manifest metadata (including `script_path`).
+- `mod.lua`: Entrypoint that loads the implementation and logs a startup message.
+- `mod_data.lua`: Mod options and descriptions.
+- `mission_board_unlock.lua`: Core logic for disabling the cooldown, injecting UI controls, and handling refreshes.
+- `localization/localization.lua`: Localization strings for UI labels and settings.
+
+All assets are source-only (Lua/JSON/text) so the project remains GitHub-friendly without bundled binaries.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Removes the mission board cooldown, adds a manual **Refresh Board** button, and 
 1. Create the folder structure exactly as shown (all files are required by the loader):
    - `mission_board_unlock/`
    - `mission_board_unlock/localization/`
-   - Place `mission_board_unlock.mod`, `mod.json`, `mod.lua`, `mod_data.lua`, and `mission_board_unlock.lua` directly inside `mission_board_unlock/`.
+   - Place `mission_board_unlock.mod`, `mod.json`, `mod_data.lua`, and `mission_board_unlock.lua` directly inside `mission_board_unlock/`.
    - Place `localization.lua` inside `mission_board_unlock/localization/`.
 2. Copy the entire `mission_board_unlock/` folder to `<Darktide>/mods/` so the path is `<Darktide>/mods/mission_board_unlock/`.
 3. Ensure `mod_load_order.txt` contains **only** the folder names (one per line) that match your installed mod folders:
    - `dmf` (the Darktide Mod Framework folder name)
    - `mission_board_unlock`
-4. Confirm `mission_board_unlock.mod` exists in the installed folder; this manifest is what DMF loads. `mod.json` is kept for metadata and points `script_path` to `scripts/mods/mission_board_unlock/mod.lua`.
-5. Start the game in a modded realm. You should see `Mission Board Unlock entrypoint loaded (mod.lua)` in the console when the loader picks up the mod.
+4. Confirm `mission_board_unlock.mod` exists in the installed folder; this manifest is what DMF loads. `mod.json` mirrors the same metadata and both point `script_path` to `scripts/mods/mission_board_unlock/mission_board_unlock.lua`.
+5. Start the game in a modded realm. You should see `Mission Board Unlock entrypoint loaded (mission_board_unlock.lua)` in the console when the loader picks up the mod.
 
 ## Usage
 - Open the mission board; the cooldown will be disabled automatically.
@@ -23,9 +23,9 @@ Removes the mission board cooldown, adds a manual **Refresh Board** button, and 
 ## Files
 - `mission_board_unlock.mod`: DMF manifest the loader consumes to locate scripts and options.
 - `mod.json`: Manifest metadata (including `script_path`).
-- `mod.lua`: Entrypoint that loads the implementation and logs a startup message.
+- `mod.lua`: Optional helper kept for compatibility; the manifest now points directly to `mission_board_unlock.lua`.
 - `mod_data.lua`: Mod options and descriptions.
-- `mission_board_unlock.lua`: Core logic for disabling the cooldown, injecting UI controls, and handling refreshes.
+- `mission_board_unlock.lua`: Core logic for disabling the cooldown, injecting UI controls, and handling refreshes (and logs the entrypoint load message).
 - `localization/localization.lua`: Localization strings for UI labels and settings.
 
 All assets are source-only (Lua/JSON/text) so the project remains GitHub-friendly without bundled binaries.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Removes the mission board cooldown, adds a manual **Refresh Board** button, and 
    - Place `localization.lua` inside `mission_board_unlock/localization/`.
 2. Copy the entire `mission_board_unlock/` folder to `<Darktide>/mods/` so the path is `<Darktide>/mods/mission_board_unlock/`.
 3. Ensure `mod_load_order.txt` contains **only** the folder names (one per line) that match your installed mod folders:
-   - `darktide-mod-framework` (from DMF)
+   - `dmf` (the Darktide Mod Framework folder name)
    - `mission_board_unlock`
-4. Confirm `mission_board_unlock.mod` exists in the installed folder; this manifest is what DMF loads. `mod.json` is kept for metadata and uses `script_path = "mod"` to point at `mod.lua`.
+4. Confirm `mission_board_unlock.mod` exists in the installed folder; this manifest is what DMF loads. `mod.json` is kept for metadata and points `script_path` to `scripts/mods/mission_board_unlock/mod.lua`.
 5. Start the game in a modded realm. You should see `Mission Board Unlock entrypoint loaded (mod.lua)` in the console when the loader picks up the mod.
 
 ## Usage

--- a/mod_load_order.txt
+++ b/mod_load_order.txt
@@ -1,2 +1,2 @@
-darktide-mod-framework
+dmf
 mission_board_unlock

--- a/mod_load_order.txt
+++ b/mod_load_order.txt
@@ -1,0 +1,2 @@
+darktide-mod-framework
+mission_board_unlock

--- a/scripts/mods/mission_board_unlock/localization/localization.lua
+++ b/scripts/mods/mission_board_unlock/localization/localization.lua
@@ -1,0 +1,32 @@
+return {
+    mod_name = {
+        en = "Mission Board Unlock",
+    },
+    mod_description = {
+        en = "Removes the mission board cooldown, adds a manual refresh button, and exposes map/difficulty dropdowns.",
+    },
+    unlock_board = {
+        en = "Disable mission board cooldown",
+    },
+    allow_manual_refresh = {
+        en = "Enable manual refresh button",
+    },
+    respect_backend_lock = {
+        en = "Keep backend cooldown (if any)",
+    },
+    refresh_button = {
+        en = "Refresh Board",
+    },
+    map_dropdown_label = {
+        en = "Preferred Map",
+    },
+    difficulty_dropdown_label = {
+        en = "Preferred Difficulty",
+    },
+    status_label_loading = {
+        en = "Mission Board Unlock: loading...",
+    },
+    status_label_unlocked = {
+        en = "Mission Board Unlock: cooldown disabled",
+    }
+}

--- a/scripts/mods/mission_board_unlock/mission_board_unlock.lua
+++ b/scripts/mods/mission_board_unlock/mission_board_unlock.lua
@@ -7,6 +7,27 @@ if not mod then
     return
 end
 
+-- Ensure the hook helpers are present before attempting to use them. If any are
+-- missing (e.g., DMF not fully initialized), exit early so the loader does not
+-- raise a nil-call error during startup.
+for _, fn in ipairs({ "hook_require", "hook_safe", "hook" }) do
+    if mod[fn] == nil then
+        print(string.format("[mission_board_unlock] DMF helper '%s' missing; aborting implementation load", fn))
+        return
+    end
+end
+
+local function localize(key, fallback)
+    if mod and mod.localize then
+        local ok, value = pcall(mod.localize, mod, key)
+        if ok and value then
+            return value
+        end
+    end
+
+    return fallback
+end
+
 -- Startup confirmation so the loader log clearly shows when the mod entrypoint is executed
 mod:info("Mission Board Unlock entrypoint loaded (mission_board_unlock.lua)")
 
@@ -17,10 +38,10 @@ end
 
 -- Attempt to pull map/difficulty catalogs at load so selectors can be populated
 local map_options = {
-    { text = mod:localize("map_dropdown_label"), value = "any" },
+    { text = localize("map_dropdown_label", "Preferred Map"), value = "any" },
 }
 local difficulty_options = {
-    { text = mod:localize("difficulty_dropdown_label"), value = "any" },
+    { text = localize("difficulty_dropdown_label", "Preferred Difficulty"), value = "any" },
 }
 
 -- Keep state to avoid infinite rerolls
@@ -67,7 +88,7 @@ mod:hook_require("scripts/ui/views/mission_board_view/mission_board_view_definit
         pass_template = "button_primary",
         scenegraph_id = anchor_id,
         content = {
-            text = mod:localize("refresh_button"),
+            text = localize("refresh_button", "Refresh Board"),
             hotspot = {},
         },
         style = {
@@ -80,8 +101,8 @@ mod:hook_require("scripts/ui/views/mission_board_view/mission_board_view_definit
         pass_template = "button_secondary",
         scenegraph_id = anchor_id,
         content = {
-            label = mod:localize("map_dropdown_label"),
-            text = mod:localize("map_dropdown_label"),
+            label = localize("map_dropdown_label", "Preferred Map"),
+            text = localize("map_dropdown_label", "Preferred Map"),
             hotspot = {},
         },
         style = {
@@ -94,8 +115,8 @@ mod:hook_require("scripts/ui/views/mission_board_view/mission_board_view_definit
         pass_template = "button_secondary",
         scenegraph_id = anchor_id,
         content = {
-            label = mod:localize("difficulty_dropdown_label"),
-            text = mod:localize("difficulty_dropdown_label"),
+            label = localize("difficulty_dropdown_label", "Preferred Difficulty"),
+            text = localize("difficulty_dropdown_label", "Preferred Difficulty"),
             hotspot = {},
         },
         style = {
@@ -108,7 +129,7 @@ mod:hook_require("scripts/ui/views/mission_board_view/mission_board_view_definit
         pass_template = "text_area",
         scenegraph_id = anchor_id,
         content = {
-            text = mod:localize("status_label_loading"),
+            text = localize("status_label_loading", "Mission Board Unlock: loading..."),
         },
         style = {
             text_color = { 255, 200, 255, 200 },
@@ -196,7 +217,7 @@ local function unlock_refresh_state(self)
 
         local status = self._widgets_by_name.unlock_status
         if status and status.content then
-            status.content.text = mod:localize("status_label_unlocked")
+            status.content.text = localize("status_label_unlocked", "Mission Board Unlock: cooldown disabled")
         end
     end
 end

--- a/scripts/mods/mission_board_unlock/mission_board_unlock.lua
+++ b/scripts/mods/mission_board_unlock/mission_board_unlock.lua
@@ -1,0 +1,351 @@
+local mod = get_mod("mission_board_unlock")
+
+-- Utility: reads user config flags
+local function is_enabled(setting_id)
+    return mod:get(setting_id) ~= false
+end
+
+-- Attempt to pull map/difficulty catalogs at load so selectors can be populated
+local map_options = {
+    { text = mod:localize("map_dropdown_label"), value = "any" },
+}
+local difficulty_options = {
+    { text = mod:localize("difficulty_dropdown_label"), value = "any" },
+}
+
+-- Keep state to avoid infinite rerolls
+local rerolled_for_preferences = false
+local widgets_instantiated = false
+
+-- Populate selectors when the mission board UI module is loaded
+mod:hook_require("scripts/ui/views/mission_board_view/mission_board_view_definitions", function(definitions)
+    if not definitions then
+        return definitions
+    end
+
+    -- Some Darktide builds expose widget definitions via `widget_definitions` (map) plus a
+    -- `widgets` array of names. Others use `widgets` as the definition map itself. Handle both
+    -- so our controls get instantiated and added to the rendering list.
+    local widget_definitions = definitions.widget_definitions or definitions.widgets or {}
+    definitions.widget_definitions = widget_definitions
+
+    -- Ensure a predictable anchor; fall back to screen if the panel is missing
+    local anchor_parent = "panel_area"
+    if not (definitions.scenegraph_definition and definitions.scenegraph_definition[anchor_parent]) then
+        anchor_parent = "screen"
+    end
+
+    local anchor_id = "mission_board_unlock_anchor"
+    definitions.scenegraph_definition = definitions.scenegraph_definition or {}
+    if not definitions.scenegraph_definition[anchor_id] then
+        definitions.scenegraph_definition[anchor_id] = {
+            parent = anchor_parent,
+            vertical_alignment = "top",
+            horizontal_alignment = "right",
+            size = { 320, 180 },
+            position = { -20, -60, 2 },
+        }
+    end
+
+    local function insert_widget(name, widget)
+        if not widget_definitions[name] then
+            widget_definitions[name] = widget
+        end
+    end
+
+    insert_widget("refresh_button", {
+        pass_template = "button_primary",
+        scenegraph_id = anchor_id,
+        content = {
+            text = mod:localize("refresh_button"),
+            hotspot = {},
+        },
+        style = {
+            size = { 320, 42 },
+            offset = { 0, 0, 1 },
+        },
+    })
+
+    insert_widget("map_button", {
+        pass_template = "button_secondary",
+        scenegraph_id = anchor_id,
+        content = {
+            label = mod:localize("map_dropdown_label"),
+            text = mod:localize("map_dropdown_label"),
+            hotspot = {},
+        },
+        style = {
+            size = { 320, 36 },
+            offset = { 0, 52, 1 },
+        },
+    })
+
+    insert_widget("difficulty_button", {
+        pass_template = "button_secondary",
+        scenegraph_id = anchor_id,
+        content = {
+            label = mod:localize("difficulty_dropdown_label"),
+            text = mod:localize("difficulty_dropdown_label"),
+            hotspot = {},
+        },
+        style = {
+            size = { 320, 36 },
+            offset = { 0, 96, 1 },
+        },
+    })
+
+    insert_widget("unlock_status", {
+        pass_template = "text_area",
+        scenegraph_id = anchor_id,
+        content = {
+            text = mod:localize("status_label_loading"),
+        },
+        style = {
+            text_color = { 255, 200, 255, 200 },
+            font_size = 18,
+            size = { 320, 60 },
+            offset = { 0, 140, 1 },
+        },
+    })
+
+    -- Guarantee the widgets are part of the instantiation list when `widgets` is an array of names
+    if type(definitions.widgets) == "table" then
+        local function ensure_widget_name(name)
+            for _, entry in ipairs(definitions.widgets) do
+                if entry == name or entry.name == name then
+                    return
+                end
+            end
+
+            table.insert(definitions.widgets, name)
+        end
+
+        ensure_widget_name("refresh_button")
+        ensure_widget_name("map_button")
+        ensure_widget_name("difficulty_button")
+        ensure_widget_name("unlock_status")
+    end
+
+    return definitions
+end)
+
+local function ensure_widget_instances(self)
+    if not (self._definitions and self._ui_scenegraph and self._widgets_by_name and self._widgets) then
+        return
+    end
+
+    local widget_definitions = self._definitions.widget_definitions or self._definitions.widgets or {}
+    local widget_names = {
+        "refresh_button",
+        "map_button",
+        "difficulty_button",
+        "unlock_status",
+    }
+
+    local injected = false
+
+    for _, name in ipairs(widget_names) do
+        local definition = widget_definitions[name]
+        if definition and not self._widgets_by_name[name] then
+            local widget = self:_create_widget(name, definition)
+            if widget then
+                self._widgets_by_name[name] = widget
+                self._widgets[#self._widgets + 1] = widget
+                injected = true
+            end
+        end
+    end
+
+    if injected and not widgets_instantiated then
+        widgets_instantiated = true
+        mod:echo("Mission Board Unlock UI widgets injected into mission board view.")
+    end
+end
+
+local function unlock_refresh_state(self)
+    if not is_enabled("unlock_board") then
+        return
+    end
+
+    self._cooldown_time = 0
+    self._refresh_cooldown = 0
+    self._refresh_locked = false
+
+    local service = self._mission_board and self._mission_board._mission_board_service
+    if service then
+        service._refresh_cooldown = 0
+        service._refresh_locked = false
+        service._next_refresh_time = 0
+    end
+
+    if self._widgets_by_name then
+        local button = self._widgets_by_name.refresh_button
+        if button and button.content then
+            button.content.disabled = false
+        end
+
+        local status = self._widgets_by_name.unlock_status
+        if status and status.content then
+            status.content.text = mod:localize("status_label_unlocked")
+        end
+    end
+end
+
+local function refresh_board(self, preferred_map, preferred_difficulty)
+    local service = self._mission_board and self._mission_board._mission_board_service
+    if service and service.refresh_missions then
+        service:refresh_missions({
+            preferred_map = preferred_map,
+            preferred_difficulty = preferred_difficulty,
+        })
+        mod:echo("Mission board refreshed (cooldown bypassed).")
+    else
+        mod:echo("Mission board service unavailable; cannot refresh.")
+    end
+end
+
+local function cycle_option(widget, options)
+    if not widget or not widget.content or not options then
+        return nil
+    end
+
+    local current_index = widget.content._current_index or 1
+    local next_index = current_index + 1
+    if next_index > #options then
+        next_index = 1
+    end
+
+    widget.content._current_index = next_index
+    widget.content.text = string.format("%s: %s", widget.content.label, options[next_index].text)
+
+    return options[next_index].value
+end
+
+local function ensure_selector_text(widget, options)
+    if widget and widget.content and options and not widget.content._current_index then
+        widget.content._current_index = 1
+        widget.content.text = string.format("%s: %s", widget.content.label, options[1].text)
+    end
+end
+
+local function read_selector_value(widget, options)
+    if widget and widget.content and widget.content._current_index then
+        return options[widget.content._current_index].value
+    end
+
+    return "any"
+end
+
+-- Hook the mission board view/controller to disable timers and add callbacks
+mod:hook_require("scripts/ui/views/mission_board_view/mission_board_view", function(view)
+    -- force cooldown off as soon as the view opens
+    mod:hook_safe(view, "on_enter", function(self)
+        ensure_widget_instances(self)
+        unlock_refresh_state(self)
+
+        ensure_selector_text(self._widgets_by_name and self._widgets_by_name.map_button, map_options)
+        ensure_selector_text(self._widgets_by_name and self._widgets_by_name.difficulty_button, difficulty_options)
+
+        if is_enabled("allow_manual_refresh") then
+            refresh_board(self)
+        end
+
+        if self._widgets_by_name then
+            mod:echo("Mission Board Unlock UI attached (refresh/map/difficulty/status).")
+        else
+            mod:echo("Mission Board Unlock: widget table missing; view may be incompatible.")
+        end
+    end)
+
+    -- keep cooldown disabled while the view runs
+    mod:hook_safe(view, "update", function(self, ...)
+        ensure_widget_instances(self)
+        unlock_refresh_state(self)
+
+        local map_widget = self._widgets_by_name and self._widgets_by_name.map_button
+        local diff_widget = self._widgets_by_name and self._widgets_by_name.difficulty_button
+        ensure_selector_text(map_widget, map_options)
+        ensure_selector_text(diff_widget, difficulty_options)
+
+        if map_widget and map_widget.content and map_widget.content.hotspot and map_widget.content.hotspot.on_pressed then
+            cycle_option(map_widget, map_options)
+        end
+
+        if diff_widget and diff_widget.content and diff_widget.content.hotspot and diff_widget.content.hotspot.on_pressed then
+            cycle_option(diff_widget, difficulty_options)
+        end
+
+        local button = self._widgets_by_name and self._widgets_by_name.refresh_button
+        if button and button.content and button.content.hotspot and button.content.hotspot.on_pressed then
+            local preferred_map = read_selector_value(map_widget, map_options)
+            local preferred_difficulty = read_selector_value(diff_widget, difficulty_options)
+
+            refresh_board(self, preferred_map, preferred_difficulty)
+            self._refresh_locked = not is_enabled("unlock_board")
+        end
+    end)
+
+    -- override mission selection/refresh pipeline to respect dropdown choices when possible
+    mod:hook_safe(view, "_handle_backend_mission_result", function(self, missions)
+        local preferred_map = read_selector_value(self._widgets_by_name and self._widgets_by_name.map_button, map_options)
+        local preferred_difficulty = read_selector_value(self._widgets_by_name and self._widgets_by_name.difficulty_button, difficulty_options)
+
+        local function matches_preferences(mission)
+            local ok_map = preferred_map == "any" or mission.map == preferred_map or mission.map_name == preferred_map
+            local ok_diff = preferred_difficulty == "any" or mission.difficulty == preferred_difficulty or mission.challenge == preferred_difficulty
+            return ok_map and ok_diff
+        end
+
+        if preferred_map ~= "any" or preferred_difficulty ~= "any" then
+            local all_match = true
+            for _, mission in pairs(missions or {}) do
+                if not matches_preferences(mission) then
+                    all_match = false
+                    break
+                end
+            end
+
+            -- If nothing matches, and backend refresh is allowed, reroll once
+            if not all_match and not is_enabled("respect_backend_lock") and not rerolled_for_preferences then
+                rerolled_for_preferences = true
+                refresh_board(self, preferred_map, preferred_difficulty)
+                return
+            end
+        end
+
+        rerolled_for_preferences = false
+    end)
+
+    return view
+end)
+
+-- Fallback catalog population: try to read missions when the service is loaded
+mod:hook_require("scripts/managers/live_event/live_event_manager", function(manager)
+    mod:hook_safe(manager, "_cache_missions", function(self, missions)
+        if not missions then
+            return
+        end
+
+        local seen_maps = {}
+        local seen_difficulties = {}
+        for _, mission in pairs(missions) do
+            if mission.map and not seen_maps[mission.map] then
+                seen_maps[mission.map] = true
+                table.insert(map_options, { text = mission.map, value = mission.map })
+            end
+            if mission.difficulty and not seen_difficulties[mission.difficulty] then
+                seen_difficulties[mission.difficulty] = true
+                table.insert(difficulty_options, { text = mission.difficulty, value = mission.difficulty })
+            end
+        end
+    end)
+
+    return manager
+end)
+
+-- Simple debug log so users can confirm the mod loaded
+mod:echo(
+    "Mission Board Unlock loaded. Cooldowns disabled: %s, manual refresh: %s",
+    tostring(is_enabled("unlock_board")),
+    tostring(is_enabled("allow_manual_refresh"))
+)

--- a/scripts/mods/mission_board_unlock/mission_board_unlock.lua
+++ b/scripts/mods/mission_board_unlock/mission_board_unlock.lua
@@ -1,5 +1,10 @@
 local mod = get_mod("mission_board_unlock")
 
+if not mod then
+    Log.error("mission_board_unlock", "get_mod returned nil in mission_board_unlock.lua; aborting")
+    return
+end
+
 -- Startup confirmation so the loader log clearly shows when the mod entrypoint is executed
 mod:info("Mission Board Unlock entrypoint loaded (mission_board_unlock.lua)")
 

--- a/scripts/mods/mission_board_unlock/mission_board_unlock.lua
+++ b/scripts/mods/mission_board_unlock/mission_board_unlock.lua
@@ -7,6 +7,22 @@ if not mod then
     return
 end
 
+local function log_info(message)
+    if mod.info then
+        mod:info(message)
+    else
+        print("[mission_board_unlock] " .. message)
+    end
+end
+
+local function log_echo(message)
+    if mod.echo then
+        mod:echo(message)
+    else
+        print("[mission_board_unlock] " .. message)
+    end
+end
+
 -- Ensure the hook helpers are present before attempting to use them. If any are
 -- missing (e.g., DMF not fully initialized), exit early so the loader does not
 -- raise a nil-call error during startup.
@@ -29,7 +45,7 @@ local function localize(key, fallback)
 end
 
 -- Startup confirmation so the loader log clearly shows when the mod entrypoint is executed
-mod:info("Mission Board Unlock entrypoint loaded (mission_board_unlock.lua)")
+log_info("Mission Board Unlock entrypoint loaded (mission_board_unlock.lua)")
 
 -- Utility: reads user config flags
 local function is_enabled(setting_id)
@@ -189,7 +205,7 @@ local function ensure_widget_instances(self)
 
     if injected and not widgets_instantiated then
         widgets_instantiated = true
-        mod:echo("Mission Board Unlock UI widgets injected into mission board view.")
+        log_echo("Mission Board Unlock UI widgets injected into mission board view.")
     end
 end
 
@@ -229,9 +245,9 @@ local function refresh_board(self, preferred_map, preferred_difficulty)
             preferred_map = preferred_map,
             preferred_difficulty = preferred_difficulty,
         })
-        mod:echo("Mission board refreshed (cooldown bypassed).")
+        log_echo("Mission board refreshed (cooldown bypassed).")
     else
-        mod:echo("Mission board service unavailable; cannot refresh.")
+        log_echo("Mission board service unavailable; cannot refresh.")
     end
 end
 
@@ -282,9 +298,9 @@ mod:hook_require("scripts/ui/views/mission_board_view/mission_board_view", funct
         end
 
         if self._widgets_by_name then
-            mod:echo("Mission Board Unlock UI attached (refresh/map/difficulty/status).")
+            log_echo("Mission Board Unlock UI attached (refresh/map/difficulty/status).")
         else
-            mod:echo("Mission Board Unlock: widget table missing; view may be incompatible.")
+            log_echo("Mission Board Unlock: widget table missing; view may be incompatible.")
         end
     end)
 
@@ -375,8 +391,10 @@ mod:hook_require("scripts/managers/live_event/live_event_manager", function(mana
 end)
 
 -- Simple debug log so users can confirm the mod loaded
-mod:echo(
-    "Mission Board Unlock loaded. Cooldowns disabled: %s, manual refresh: %s",
-    tostring(is_enabled("unlock_board")),
-    tostring(is_enabled("allow_manual_refresh"))
+log_echo(
+    string.format(
+        "Mission Board Unlock loaded. Cooldowns disabled: %s, manual refresh: %s",
+        tostring(is_enabled("unlock_board")),
+        tostring(is_enabled("allow_manual_refresh"))
+    )
 )

--- a/scripts/mods/mission_board_unlock/mission_board_unlock.lua
+++ b/scripts/mods/mission_board_unlock/mission_board_unlock.lua
@@ -1,7 +1,9 @@
 local mod = get_mod("mission_board_unlock")
 
+-- If the mod API is unavailable, avoid calling Log helpers (they may also be nil) and
+-- exit quietly so the loader doesn't crash while scanning mods.
 if not mod then
-    Log.error("mission_board_unlock", "get_mod returned nil in mission_board_unlock.lua; aborting")
+    print("[mission_board_unlock] get_mod returned nil in mission_board_unlock.lua; aborting")
     return
 end
 

--- a/scripts/mods/mission_board_unlock/mission_board_unlock.lua
+++ b/scripts/mods/mission_board_unlock/mission_board_unlock.lua
@@ -1,5 +1,8 @@
 local mod = get_mod("mission_board_unlock")
 
+-- Startup confirmation so the loader log clearly shows when the mod entrypoint is executed
+mod:info("Mission Board Unlock entrypoint loaded (mission_board_unlock.lua)")
+
 -- Utility: reads user config flags
 local function is_enabled(setting_id)
     return mod:get(setting_id) ~= false

--- a/scripts/mods/mission_board_unlock/mission_board_unlock.mod
+++ b/scripts/mods/mission_board_unlock/mission_board_unlock.mod
@@ -5,6 +5,6 @@ return {
     version = "1.0.0",
     is_mutator = false,
     is_togglable = true,
-    script_path = "mod",
-    options_path = "mod_data",
+    script_path = "scripts/mods/mission_board_unlock/mod",
+    options_path = "scripts/mods/mission_board_unlock/mod_data",
 }

--- a/scripts/mods/mission_board_unlock/mission_board_unlock.mod
+++ b/scripts/mods/mission_board_unlock/mission_board_unlock.mod
@@ -6,6 +6,6 @@ return {
     is_mutator = false,
     is_togglable = true,
     is_enabled_by_default = true,
-    script_path = "scripts/mods/mission_board_unlock/mission_board_unlock",
+    script_path = "scripts/mods/mission_board_unlock/mod",
     options_path = "scripts/mods/mission_board_unlock/mod_data",
 }

--- a/scripts/mods/mission_board_unlock/mission_board_unlock.mod
+++ b/scripts/mods/mission_board_unlock/mission_board_unlock.mod
@@ -1,0 +1,10 @@
+return {
+    name = "mission_board_unlock",
+    description = "Removes the mission board cooldown, adds refresh/map/difficulty controls, and keeps the board unlocked.",
+    author = "Community",
+    version = "1.0.0",
+    is_mutator = false,
+    is_togglable = true,
+    script_path = "mod",
+    options_path = "mod_data",
+}

--- a/scripts/mods/mission_board_unlock/mission_board_unlock.mod
+++ b/scripts/mods/mission_board_unlock/mission_board_unlock.mod
@@ -5,6 +5,7 @@ return {
     version = "1.0.0",
     is_mutator = false,
     is_togglable = true,
-    script_path = "scripts/mods/mission_board_unlock/mod",
+    is_enabled_by_default = true,
+    script_path = "scripts/mods/mission_board_unlock/mission_board_unlock",
     options_path = "scripts/mods/mission_board_unlock/mod_data",
 }

--- a/scripts/mods/mission_board_unlock/mission_board_unlock.mod
+++ b/scripts/mods/mission_board_unlock/mission_board_unlock.mod
@@ -9,6 +9,6 @@ return {
     dependencies = {
         "dmf",
     },
-    script_path = "scripts/mods/mission_board_unlock/mod",
+    script_path = "scripts/mods/mission_board_unlock/mod.lua",
     options_path = "scripts/mods/mission_board_unlock/mod_data",
 }

--- a/scripts/mods/mission_board_unlock/mission_board_unlock.mod
+++ b/scripts/mods/mission_board_unlock/mission_board_unlock.mod
@@ -6,6 +6,9 @@ return {
     is_mutator = false,
     is_togglable = true,
     is_enabled_by_default = true,
+    dependencies = {
+        "dmf",
+    },
     script_path = "scripts/mods/mission_board_unlock/mod",
     options_path = "scripts/mods/mission_board_unlock/mod_data",
 }

--- a/scripts/mods/mission_board_unlock/mod.json
+++ b/scripts/mods/mission_board_unlock/mod.json
@@ -8,5 +8,5 @@
   "dependencies": [
     "dmf"
   ],
-  "script_path": "scripts/mods/mission_board_unlock/mod"
+  "script_path": "scripts/mods/mission_board_unlock/mod.lua"
 }

--- a/scripts/mods/mission_board_unlock/mod.json
+++ b/scripts/mods/mission_board_unlock/mod.json
@@ -5,5 +5,8 @@
   "version": "1.0.0",
   "is_togglable": true,
   "is_enabled_by_default": true,
+  "dependencies": [
+    "dmf"
+  ],
   "script_path": "scripts/mods/mission_board_unlock/mod"
 }

--- a/scripts/mods/mission_board_unlock/mod.json
+++ b/scripts/mods/mission_board_unlock/mod.json
@@ -4,5 +4,6 @@
   "author": "Community",
   "version": "1.0.0",
   "is_togglable": true,
-  "script_path": "scripts/mods/mission_board_unlock/mod"
+  "is_enabled_by_default": true,
+  "script_path": "scripts/mods/mission_board_unlock/mission_board_unlock"
 }

--- a/scripts/mods/mission_board_unlock/mod.json
+++ b/scripts/mods/mission_board_unlock/mod.json
@@ -5,5 +5,5 @@
   "version": "1.0.0",
   "is_togglable": true,
   "is_enabled_by_default": true,
-  "script_path": "scripts/mods/mission_board_unlock/mission_board_unlock"
+  "script_path": "scripts/mods/mission_board_unlock/mod"
 }

--- a/scripts/mods/mission_board_unlock/mod.json
+++ b/scripts/mods/mission_board_unlock/mod.json
@@ -4,5 +4,5 @@
   "author": "Community",
   "version": "1.0.0",
   "is_togglable": true,
-  "script_path": "mod"
+  "script_path": "scripts/mods/mission_board_unlock/mod"
 }

--- a/scripts/mods/mission_board_unlock/mod.json
+++ b/scripts/mods/mission_board_unlock/mod.json
@@ -1,0 +1,8 @@
+{
+  "name": "mission_board_unlock",
+  "description": "Removes the mission board cooldown, adds refresh/map/difficulty controls, and keeps the board unlocked.",
+  "author": "Community",
+  "version": "1.0.0",
+  "is_togglable": true,
+  "script_path": "mod"
+}

--- a/scripts/mods/mission_board_unlock/mod.lua
+++ b/scripts/mods/mission_board_unlock/mod.lua
@@ -1,7 +1,14 @@
 local mod = get_mod("mission_board_unlock")
 
+-- Load localization strings early so settings and UI labels resolve even if the
+-- implementation hooks run slightly later.
+local localization = require("scripts/mods/mission_board_unlock/localization/localization")
+if localization then
+    mod:add_localized_strings(localization)
+end
+
 -- Load the main implementation from the same directory
-mod:io_dofile("scripts/mods/mission_board_unlock/mission_board_unlock")
+mod:io_dofile("scripts/mods/mission_board_unlock/mission_board_unlock.lua")
 
 -- Surface a clear log message when the entrypoint loads so players can confirm the
 -- mod was picked up by the loader before the mission board view initializes.

--- a/scripts/mods/mission_board_unlock/mod.lua
+++ b/scripts/mods/mission_board_unlock/mod.lua
@@ -1,10 +1,13 @@
 local mod = get_mod("mission_board_unlock")
 
 -- Load localization strings early so settings and UI labels resolve even if the
--- implementation hooks run slightly later.
+-- implementation hooks run slightly later. The add_localized_strings helper is
+-- not guaranteed on every DMF build, so guard it to avoid nil-call failures.
 local localization = require("scripts/mods/mission_board_unlock/localization/localization")
-if localization then
+if localization and mod.add_localized_strings then
     mod:add_localized_strings(localization)
+elseif localization then
+    mod:info("Mission Board Unlock: localization loaded (no add_localized_strings helper present)")
 end
 
 -- Load the main implementation from the same directory

--- a/scripts/mods/mission_board_unlock/mod.lua
+++ b/scripts/mods/mission_board_unlock/mod.lua
@@ -1,0 +1,8 @@
+local mod = get_mod("mission_board_unlock")
+
+-- Load the main implementation from the same directory
+mod:io_dofile("scripts/mods/mission_board_unlock/mission_board_unlock")
+
+-- Surface a clear log message when the entrypoint loads so players can confirm the
+-- mod was picked up by the loader before the mission board view initializes.
+mod:info("Mission Board Unlock entrypoint loaded (mod.lua)")

--- a/scripts/mods/mission_board_unlock/mod.lua
+++ b/scripts/mods/mission_board_unlock/mod.lua
@@ -1,7 +1,9 @@
 local mod = get_mod("mission_board_unlock")
 
+-- If the mod API is unavailable, bail out quietly to avoid nil-call crashes. Do not
+-- use Log.* helpers here because they may also be missing when get_mod fails.
 if not mod then
-    Log.error("mission_board_unlock", "get_mod returned nil in mod.lua; aborting entrypoint load")
+    print("[mission_board_unlock] get_mod returned nil in mod.lua; aborting entrypoint load")
     return
 end
 

--- a/scripts/mods/mission_board_unlock/mod.lua
+++ b/scripts/mods/mission_board_unlock/mod.lua
@@ -7,6 +7,14 @@ if not mod then
     return
 end
 
+-- Make sure the DMF API we rely on is present before proceeding. If any
+-- required helper is missing, abort cleanly so the loader doesn't throw a
+-- nil-call error while scanning mods.
+if mod.io_dofile == nil then
+    print("[mission_board_unlock] DMF helper 'io_dofile' missing; aborting entrypoint load")
+    return
+end
+
 -- Gracefully load other Lua files even if the DMF helper `io_dofile` is missing
 -- in this environment. If it's absent, fall back to plain dofile so the loader
 -- doesn't crash with "attempt to call a nil value".

--- a/scripts/mods/mission_board_unlock/mod.lua
+++ b/scripts/mods/mission_board_unlock/mod.lua
@@ -7,6 +7,24 @@ if not mod then
     return
 end
 
+-- Gracefully load other Lua files even if the DMF helper `io_dofile` is missing
+-- in this environment. If it's absent, fall back to plain dofile so the loader
+-- doesn't crash with "attempt to call a nil value".
+local function safe_dofile(path)
+    if mod.io_dofile then
+        return mod:io_dofile(path)
+    end
+
+    -- DMF normally resolves mod-relative paths automatically; mimic that
+    -- behaviour by appending ".lua" when using the vanilla loader.
+    local ok, result = pcall(dofile, path .. ".lua")
+    if not ok then
+        print(string.format("[mission_board_unlock] failed to load %s: %s", path, tostring(result)))
+    end
+
+    return result
+end
+
 -- Load localization strings early so settings and UI labels resolve even if the
 -- implementation hooks run slightly later. The add_localized_strings helper is
 -- not guaranteed on every DMF build, so guard it to avoid nil-call failures.
@@ -18,8 +36,12 @@ elseif localization then
 end
 
 -- Load the main implementation from the same directory
-mod:io_dofile("scripts/mods/mission_board_unlock/mission_board_unlock.lua")
+safe_dofile("scripts/mods/mission_board_unlock/mission_board_unlock")
 
 -- Surface a clear log message when the entrypoint loads so players can confirm the
 -- mod was picked up by the loader before the mission board view initializes.
-mod:info("Mission Board Unlock entrypoint loaded (mod.lua)")
+if mod.info then
+    mod:info("Mission Board Unlock entrypoint loaded (mod.lua)")
+else
+    print("[mission_board_unlock] entrypoint loaded (mod.lua)")
+end

--- a/scripts/mods/mission_board_unlock/mod.lua
+++ b/scripts/mods/mission_board_unlock/mod.lua
@@ -1,5 +1,10 @@
 local mod = get_mod("mission_board_unlock")
 
+if not mod then
+    Log.error("mission_board_unlock", "get_mod returned nil in mod.lua; aborting entrypoint load")
+    return
+end
+
 -- Load localization strings early so settings and UI labels resolve even if the
 -- implementation hooks run slightly later. The add_localized_strings helper is
 -- not guaranteed on every DMF build, so guard it to avoid nil-call failures.

--- a/scripts/mods/mission_board_unlock/mod_data.lua
+++ b/scripts/mods/mission_board_unlock/mod_data.lua
@@ -1,8 +1,22 @@
 local mod = get_mod("mission_board_unlock")
 
+local function safe_localize(key, fallback)
+    if mod and mod.localize then
+        local ok, value = pcall(mod.localize, mod, key)
+        if ok and value then
+            return value
+        end
+    end
+
+    return fallback
+end
+
 return {
-    name = mod:localize("mod_name"),
-    description = mod:localize("mod_description"),
+    name = safe_localize("mod_name", "Mission Board Unlock"),
+    description = safe_localize(
+        "mod_description",
+        "Removes the mission board cooldown, adds a manual refresh button, and exposes map/difficulty dropdowns."
+    ),
     author = "Community",
     version = "1.0.0",
     hot_reload = true,

--- a/scripts/mods/mission_board_unlock/mod_data.lua
+++ b/scripts/mods/mission_board_unlock/mod_data.lua
@@ -1,0 +1,28 @@
+local mod = get_mod("mission_board_unlock")
+
+return {
+    name = mod:localize("mod_name"),
+    description = mod:localize("mod_description"),
+    author = "Community",
+    version = "1.0.0",
+    hot_reload = true,
+    options = {
+        widgets = {
+            {
+                setting_id = "unlock_board",
+                type = "checkbox",
+                default_value = true,
+            },
+            {
+                setting_id = "allow_manual_refresh",
+                type = "checkbox",
+                default_value = true,
+            },
+            {
+                setting_id = "respect_backend_lock",
+                type = "checkbox",
+                default_value = false,
+            },
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add the DMF `mission_board_unlock.mod` manifest that points to the mod and options scripts so the loader can detect the mod
- align `mod.json` script_path with the mod entrypoint
- update installation instructions to include the .mod manifest and correct folder names

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69191125a038833180f195482b1023ba)